### PR TITLE
fsh syntax refactor, minor fixes and new proposed modeling for AuditEvent.subtype

### DIFF
--- a/input/fsh/Metadata.fsh
+++ b/input/fsh/Metadata.fsh
@@ -1,6 +1,4 @@
 RuleSet: Metadata
-* ^text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>StructureDefinition for the EdsBasicDeliveryStatus.</div>"
-* ^text.status = #additional
 * ^contact[0].name = "MedCom"
 * ^contact[=].telecom.value = "https://www.medcom.dk/"
 * ^contact[=].telecom.system = #url

--- a/input/fsh/Metadata.fsh
+++ b/input/fsh/Metadata.fsh
@@ -1,0 +1,15 @@
+RuleSet: Metadata
+* ^text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>StructureDefinition for the EdsBasicDeliveryStatus.</div>"
+* ^text.status = #additional
+* ^contact[0].name = "MedCom"
+* ^contact[=].telecom.value = "https://www.medcom.dk/"
+* ^contact[=].telecom.system = #url
+* ^contact[+].name = "OVI"
+* ^contact[=].telecom.value = "ovi@medcom.dk"
+* ^contact[=].telecom.system = #email
+//* ^jurisdiction = urn:iso:std:iso:3166#CH
+* ^status = #active
+* ^publisher = "MedCom"
+* ^date = "2025-04-01"
+* ^copyright = "CC0-1.0"
+* ^experimental = false

--- a/input/fsh/edsAliases.fsh
+++ b/input/fsh/edsAliases.fsh
@@ -17,7 +17,7 @@ Alias: $EhmiDeliveryStatusEntityMessageType = http://medcomehmi.dk/ig/terminolog
 
 Alias: $EdsSubtypes = http://hl7.org/fhir/ValueSet/audit-event-sub-type
 Alias: $EdsSubtypesVS = http://medcomehmi.dk/ig/terminology/ValueSet/ehmi-delivery-status-sub-types-valueset
-
+Alias: $EdsSubtypesCS = http://medcomehmi.dk/ig/terminology/CodeSystem/ehmi-delivery-status-sub-types
 // EER Aliases
 Alias: $MedComMessageDefinitionUri = http://medcomehmi.dk/ig/terminology/CodeSystem/ehmi-medcom-message-definition-uri
 Alias: $MedComMessageDefinitionUriVS = http://medcomehmi.dk/ig/terminology/ValueSet/ehmi-medcom-message-definition-uri-valueset

--- a/input/fsh/edsBasicDeliveryStatus.fsh
+++ b/input/fsh/edsBasicDeliveryStatus.fsh
@@ -20,60 +20,12 @@ not have a successful outcome and the EDS Client will receive an OperationOutcom
 * type MS SU
 //* type.system = "http://terminology.hl7.org/CodeSystem/audit-event-type"
 //* type.code = http://terminology.hl7.org/CodeSystem/audit-event-type#object
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 * subtype 1..1 MS SU
-* subtype.code from $EdsSubtypesVS
-// * subtype.system = $EdsSubtypes // TODO: AT - this is incorrect, as it is a ValueSet, not a CodeSystem uri
-* subtype ^slicing.discriminator.type = #value
-* subtype ^slicing.discriminator.path = "$this"
-* subtype ^slicing.rules = #open // allow other codes
-* subtype contains
-//    msg-created 0..1 and 
-    msg-created-and-sent 0..1 MS and 
-    msg-sent 0..1 MS and 
-    msg-received 0..1 MS and 
-    msg-received-and-finalized 0..1 MS 
-//    and msg-finalized 0..1 
-//* subtype[msg-created]
-/* subtype[msg-created].code 1..1
-* subtype[msg-created].system 1..1
-* subtype[msg-created].display 1..1
-* subtype[msg-created] = $EdsSubtypes#msg-created "Message created" (exactly)
-*/
-//* subtype[msg-created-and-sent]
-* subtype[msg-created-and-sent].code 1..1
-* subtype[msg-created-and-sent].system 1..1
-//* subtype[msg-created-and-sent].system = $EdsSubtypes
-//* subtype[msg-created-and-sent].display 1..1
-* subtype[msg-created-and-sent] from $EdsSubtypesVS
-* subtype[msg-created-and-sent].code = #msg-created-and-sent "Message created and sent" (exactly)
-//* subtype[msg-sent]
-* subtype[msg-sent].code 1..1
-* subtype[msg-sent].system 1..1
-//* subtype[msg-sent].system = $EdsSubtypes
-//* subtype[msg-sent].display 1..1
-* subtype[msg-sent].code from $EdsSubtypesVS
-* subtype[msg-sent].code = #msg-sent "Message sent" (exactly)
-//* subtype[msg-received]
-* subtype[msg-received].code 1..1
-* subtype[msg-received].system 1..1
-//* subtype[msg-received].system = $EdsSubtypes
-//* subtype[msg-received].display 1..1
-* subtype[msg-received].code from $EdsSubtypesVS
-* subtype[msg-received].code = #msg-received "Message received" (exactly)
-//* subtype[msg-received-and-finalized]
-* subtype[msg-received-and-finalized].code 1..1
-* subtype[msg-received-and-finalized].system 1..1
-//* subtype[msg-received-and-finalized].system = $EdsSubtypes
-//* subtype[msg-received-and-finalized].display 1..1
-* subtype[msg-received-and-finalized].code from $EdsSubtypesVS
-* subtype[msg-received-and-finalized].code = #msg-received-and-finalized "Message received and finalized" (exactly)
-//* subtype[msg-finalized]
-/* subtype[msg-finalized].code 1..1
-* subtype[msg-finalized].system 1..1
-* subtype[msg-finalized].display 1..1
-* subtype[msg-finalized] = $EdsSubtypes#msg-finalized "Message finalized" (exactly)
-*/
+* subtype.code 1..1
+* subtype.system 1..1
+* subtype from ehmi-delivery-status-sub-types-valueset (extensible) 
+* subtype ^definition = "From the 6 codes in the EdsSubtypesVS the following 4 are used: _msg-created-and-sent_, _msg-sent_, _msg-received_, _msg-received-and-finalized_" //TODO needs to be refined! Just a proposal now.
 * action 1..1
 * action = http://hl7.org/fhir/audit-event-action#C
 * period 0..0

--- a/input/fsh/edsBasicDeliveryStatus.fsh
+++ b/input/fsh/edsBasicDeliveryStatus.fsh
@@ -14,7 +14,7 @@ When the message transaction is Patient specific then EdsPatientDeliveryStatus i
 When successfully submitted from an EDS Client to the EDS Server then the recorded EdsBasicDeliveryStatus has conformed to the profile otherwise it would 
 not have a successful outcome and the EDS Client will receive an OperationOutcome indicating the failure.
 " 
-insert Metadata
+* insert Metadata
 * id 1..
 * id MS SU
 * type MS SU
@@ -23,7 +23,7 @@ insert Metadata
 * type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 * subtype 1..1 MS SU
 * subtype.code from $EdsSubtypesVS
-* subtype.system = $EdsSubtypes
+// * subtype.system = $EdsSubtypes // TODO: AT - this is incorrect, as it is a ValueSet, not a CodeSystem uri
 * subtype ^slicing.discriminator.type = #value
 * subtype ^slicing.discriminator.path = "$this"
 * subtype ^slicing.rules = #open // allow other codes
@@ -82,6 +82,7 @@ insert Metadata
 * outcomeDesc 0..0
 * purposeOfEvent 0..0
 * agent.extension contains eds-otherId named GLNId 0..* MS
+* agent.extension[GLNId].valueIdentifier.value 1..1 MS //TODO: the 1..1 is already defined in the extension, perhaps we should move the MS flag to the extension too?
 * agent ^slicing.discriminator.type = #value
 * agent ^slicing.discriminator.path = "type"
 * agent ^slicing.rules = #open
@@ -90,11 +91,9 @@ insert Metadata
     ehmiReceiver 1..1 
 * agent 2..4
 //* ^agent[ehmiSender]
-* agent[ehmiSender].extension contains GLNId named gln 0..* 
 * agent[ehmiSender].name 0..1 MS 
 * agent[ehmiSender].type 1..1 MS 
-* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
 * agent[ehmiSender].who 1..1 MS
 * agent[ehmiSender].who only Reference(Organization)
 * agent[ehmiSender].who.identifier 1..1 MS SU
@@ -102,21 +101,13 @@ insert Metadata
 //* agent[ehmiSender].who.type 0..1 MS SU
 //* agent[ehmiSender].who.type from $EhmiDeliveryStatusAgentWhoIdentifierTypesValueset
 //* agent[ehmiSender].who.type ^short = "SOR"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type ^short = "GLN"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value 1..1 MS
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value ^short = "equals SBDH/Sender/Identifier"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type ^short = "GLN"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value ^short = "equals SBDH/Sender/Identifier"
 //* agent[ehmiReceiver]
-* agent[ehmiReceiver].extension ^slicing.discriminator[1].type = #value
-* agent[ehmiReceiver].extension ^slicing.discriminator[=].path = "value.ofType(Identifier).type"
-* agent[ehmiReceiver].extension[GLNId] contains 
-	  gln 0..* 
 * agent[ehmiReceiver].name 1..1 MS
 * agent[ehmiReceiver].type 1..1 MS
-* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who 1..1 MS
 * agent[ehmiReceiver].who only Reference(Organization)
 * agent[ehmiReceiver].who.identifier 1..1 MS SU
@@ -124,17 +115,16 @@ insert Metadata
 //* agent[ehmiReceiver].who.type from $EhmiDeliveryStatusAgentWhoIdentifierTypesValueset
 //* agent[ehmiReceiver].who.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#SOR 
 //* agent[ehmiReceiver].who.type  ^short = "SOR"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type ^short = "GLN"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value 1..1 MS
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value ^short = "equals SBDH/Receiver/Identifier"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type ^short = "GLN"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value ^short = "equals SBDH/Receiver/Identifier"
 //source
 * source.observer 1..1 
 * source.observer only Reference(Device)
 * source.type 1..1 MS 
 * source.type from $EhmiDeliveryStatusSourceTypeValueSet
 * source.type.system = $EhmiDeliveryStatusSourceType
-* source.observer.type = $EhmiDeliveryStatusParticipationRoleType#ehmiDevice
+* source.observer.type = $EhmiDeliveryStatusParticipationRoleType#ehmiDevice // TODO: I think this should be fixed for Device form FHIR codes, not the 'ehmiDevice' code
 * source.observer.identifier 0..1 MS SU
 * contained.id
 // entity
@@ -142,8 +132,8 @@ insert Metadata
 * entity ^slicing.discriminator.type = #value
 * entity ^slicing.discriminator.path = "type.code"
 * entity ^slicing.rules = #open
+* entity.type from $EhmiDeliveryStatusEntityTypeValueSet
 * entity.type.system = $EhmiDeliveryStatusEntityType
-* entity.type.code from $EhmiDeliveryStatusEntityTypeValueSet
 * entity contains
     ehmiMessage 1..1 and
     ehmiMessageEnvelope 0..1 and
@@ -155,37 +145,23 @@ insert Metadata
 * entity[ehmiMessage].type.code 1..1 MS 
 * entity[ehmiMessage].type.system 1..1 MS 
 * entity[ehmiMessage].type.display 1..1 MS
-//* entity[ehmiMessage].type.code from $EhmiDeliveryStatusEntityTypeValueSet
-* entity[ehmiMessage].type.code = #ehmiMessage (exactly)
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
 * entity[ehmiMessage].detail.type from $EhmiDeliveryStatusEntityDetailTypeValueSet
 * entity[ehmiMessage].detail ^slicing.discriminator.type = #value
-  * ^slicing.discriminator.path = type
-  * ^slicing.rules = #open 
-  * ^short = "something short"
+* entity[ehmiMessage].detail ^slicing.discriminator.path = type
+* entity[ehmiMessage].detail ^slicing.rules = #open // TODO based on card of 2...3 i would say this is a closed slicing?
+* entity[ehmiMessage].detail ^short = "something short"
 * entity[ehmiMessage].detail contains
     ehmiMessageType 1..1 and
     ehmiMessageVersion 1..1 and
     ehmiStatisticalInfo 0..1 
 * entity[ehmiMessage].detail 2..3
-
-//* entity[ehmiMessage].detail[ehmiMessageType].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-//* entity[ehmiMessage].detail[ehmiMessageType].type.value = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType (exactly)
 * entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType (exactly)
 * entity[ehmiMessage].detail[ehmiMessageType].valueString 1..1
 * entity[ehmiMessage].detail[ehmiMessageType].valueString ^short = "equals 'SBDH/DocumentIdentification/Standard/[value]' e.g. homecareobservation-message"
-//* entity[ehmiMessage].detail[ehmiMessageType].type.code from $MedComMessageDefinitionUriVS
-//* entity[ehmiMessage].detail[ehmiMessageType].type.system = $MedComMessageDefinitionUri
-
-//* entity[ehmiMessage].detail[ehmiMessageVersion].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-//* entity[ehmiMessage].detail[ehmiMessageVersion].type.value = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion (exactly)
 * entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion (exactly)
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString 1..1
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString ^short = "equals 'SBDH/DocumentIdentification/TypeVersion/[value]' e.g. 1.0"
-
-//* entity[ehmiMessage].detail[ehmiStatisticalInfo].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-//* entity[ehmiMessage].detail[ehmiStatisticalInfo].type.value = $EhmiDeliveryStatusEntityDetailType#ehmiStatisticalInfo (exactly)
 * entity[ehmiMessage].detail[ehmiStatisticalInfo].type = #ehmiStatisticalInfo (exactly)
 * entity[ehmiMessage].detail[ehmiStatisticalInfo].valueString 1..1
 * entity[ehmiMessage].detail[ehmiStatisticalInfo].valueString ^short = "equals 'MCM:' + SBDH/DocumentIdentification/Standard/[value]+'|'+SBDH/DocumentIdentification/TypeVersion/[value]+#[Postfix values]"
@@ -194,19 +170,17 @@ insert Metadata
 * entity[ehmiMessageEnvelope].type.code 1..1 MS 
 * entity[ehmiMessageEnvelope].type.system 1..1 MS 
 * entity[ehmiMessageEnvelope].type.display 1..1 MS
-* entity[ehmiMessageEnvelope].type.code = #ehmiMessageEnvelope (exactly)
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail.type from $EhmiDeliveryStatusEntityDetailTypeValueSet
 * entity[ehmiMessageEnvelope].detail ^slicing.discriminator.type = #value
-  * ^slicing.discriminator.path = type
-  * ^slicing.rules = #open 
-  * ^short = "something short"
+* entity[ehmiMessageEnvelope].detail ^slicing.discriminator.path = type
+* entity[ehmiMessageEnvelope].detail ^slicing.rules = #open 
+* entity[ehmiMessageEnvelope].detail ^short = "something short"
 * entity[ehmiMessageEnvelope].detail contains
     ehmiMessageEnvelopeType 0..1 //and
 //    ehmiMessageVersion 0..1 
 * entity[ehmiMessageEnvelope].detail 0..1
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type.value = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType (exactly)
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType (exactly)
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString 1..1
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString ^short = "equals 'SBDH/DocumentIdentification/Type/[value]' e.g. Bundle"
 //* entity[ehmiTransportEnvelope]
@@ -216,23 +190,20 @@ insert Metadata
 * entity[ehmiTransportEnvelope].type.display 1..1 MS
 //* entity[ehmiTransportEnvelope].type from $EhmiDeliveryStatusEntityTypeValueSet
 //* entity[ehmiTransportEnvelope].type = #ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = #ehmiTransportEnvelope (exactly)
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail.type from $EhmiDeliveryStatusEntityDetailTypeValueSet
 * entity[ehmiTransportEnvelope].detail ^slicing.discriminator.type = #value
-  * ^slicing.discriminator.path = type
-  * ^slicing.rules = #open 
-  * ^short = "something short"
+* entity[ehmiTransportEnvelope].detail ^slicing.discriminator.path = type
+* entity[ehmiTransportEnvelope].detail ^slicing.rules = #open 
+* entity[ehmiTransportEnvelope].detail ^short = "something short"
 * entity[ehmiTransportEnvelope].detail contains
     ehmiTransportEnvelopeType 0..1 and
     ehmiTransportEnvelopeVersion 0..1
 * entity[ehmiTransportEnvelope].detail 0..2
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType (exactly)
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType (exactly)
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString 1..1
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString ^short = "= 'SBDH'"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion (exactly)
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion (exactly)
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString 1..1
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString ^short = "equals SBDH/HeaderVersion/[value] e.g. 1.2"
 //* entity[ehmiOrigMessage]
@@ -240,48 +211,39 @@ insert Metadata
 * entity[ehmiOrigMessage].type.code 1..1 MS
 * entity[ehmiOrigMessage].type.system 1..1 MS 
 * entity[ehmiOrigMessage].type.display 1..1 MS
-//* entity[ehmiOrigMessage].type from $EhmiDeliveryStatusEntityTypeValueSet
-//* entity[ehmiOrigMessage].type = #ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = #ehmiOrigMessage (exactly)
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
+* entity[ehmiOrigMessage].detail.type from $EhmiDeliveryStatusEntityDetailTypeValueSet
 * entity[ehmiOrigMessage].detail ^slicing.discriminator.type = #value
-  * ^slicing.discriminator.path = type
-  * ^slicing.rules = #open  
-  * ^short = "something short"
+* entity[ehmiOrigMessage].detail ^slicing.discriminator.path = type
+* entity[ehmiOrigMessage].detail ^slicing.rules = #open  
+* entity[ehmiOrigMessage].detail ^short = "something short"
 * entity[ehmiOrigMessage].detail contains
     ehmiMessageType 1..1 and
     ehmiMessageVersion 1..1 
 * entity[ehmiOrigMessage].detail 2..2
-* entity[ehmiOrigMessage].detail[ehmiMessageType].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType (exactly)
+
+* entity[ehmiOrigMessage].detail[ehmiMessageType].type = #ehmiMessageType (exactly)
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString 1..1
-* entity[ehmiOrigMessage].detail[ehmiMessageVersion].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion (exactly)
+* entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion (exactly)
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString 1..1
 //* entity[ehmiOrigTransportEnvelope]
 * entity[ehmiOrigTransportEnvelope].what.identifier 1..1 MS SU
 * entity[ehmiOrigTransportEnvelope].type.code 1..1 MS
 * entity[ehmiOrigTransportEnvelope].type.system 1..1 MS 
 * entity[ehmiOrigTransportEnvelope].type.display 1..1 MS
-//* entity[ehmiOrigTransportEnvelope].type from $EhmiDeliveryStatusEntityTypeValueSet
-//* entity[ehmiOrigTransportEnvelope].type = #ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = #ehmiOrigTransportEnvelope (exactly)
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail.type from $EhmiDeliveryStatusEntityDetailTypeValueSet
 * entity[ehmiOrigTransportEnvelope].detail ^slicing.discriminator.type = #value
-  * ^slicing.discriminator.path = type
-  * ^slicing.rules = #open //#closed eller #open 
-  * ^short = "something short"
+* entity[ehmiOrigTransportEnvelope].detail ^slicing.discriminator.path = type
+* entity[ehmiOrigTransportEnvelope].detail ^slicing.rules = #open //#closed eller #open 
+* entity[ehmiOrigTransportEnvelope].detail ^short = "something short"
 * entity[ehmiOrigTransportEnvelope].detail contains
     ehmiTransportEnvelopeType 0..1 and
     ehmiTransportEnvelopeVersion 0..1
 * entity[ehmiOrigTransportEnvelope].detail 0..2
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType (exactly)
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType (exactly)
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString 1..1
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type from $EhmiDeliveryStatusEntityDetailTypeValueSet
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion (exactly)
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion (exactly)
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString 1..1
 
 Extension: EdsOtherId
@@ -292,8 +254,8 @@ Description: "Carries other identifiers that are known for an agent."
 * ^context[=].expression = "AuditEvent.agent"
 * value[x] only Identifier
 * valueIdentifier.type 1..1
-* valueIdentifier.value 1..1
-
+* valueIdentifier.value 1..1 
+ 
 Invariant: uuid
 Description: "General UUID expression"
 Severity: #error

--- a/input/fsh/edsBasicDeliveryStatus.fsh
+++ b/input/fsh/edsBasicDeliveryStatus.fsh
@@ -14,35 +14,18 @@ When the message transaction is Patient specific then EdsPatientDeliveryStatus i
 When successfully submitted from an EDS Client to the EDS Server then the recorded EdsBasicDeliveryStatus has conformed to the profile otherwise it would 
 not have a successful outcome and the EDS Client will receive an OperationOutcome indicating the failure.
 " 
-* ^url = "http://medcomehmi.dk/ig/eds/StructureDefinition/EdsBasicDeliveryStatus"
-* ^text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>StructureDefinition for the EdsBasicDeliveryStatus.</div>"
-* ^text.status = #additional
-* ^contact[0].name = "MedCom"
-* ^contact[=].telecom.value = "https://www.medcom.dk/"
-* ^contact[=].telecom.system = #url
-* ^contact[+].name = "OVI"
-* ^contact[=].telecom.value = "ovi@medcom.dk"
-* ^contact[=].telecom.system = #email
-//* ^jurisdiction = urn:iso:std:iso:3166#CH
-* ^status = #active
-* ^publisher = "MedCom"
-* ^date = "2025-04-01"
-* ^copyright = "CC0-1.0"
-* ^experimental = false
+insert Metadata
 * id 1..
 * id MS SU
 * type MS SU
 //* type.system = "http://terminology.hl7.org/CodeSystem/audit-event-type"
 //* type.code = http://terminology.hl7.org/CodeSystem/audit-event-type#object
-* type.system = $EhmiDeliveryStatusTypes
 * type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
 * subtype 1..1 MS SU
 * subtype.code from $EdsSubtypesVS
 * subtype.system = $EdsSubtypes
 * subtype ^slicing.discriminator.type = #value
-* subtype ^slicing.discriminator.path = code //"$this"
+* subtype ^slicing.discriminator.path = "$this"
 * subtype ^slicing.rules = #open // allow other codes
 * subtype contains
 //    msg-created 0..1 and 
@@ -62,7 +45,7 @@ not have a successful outcome and the EDS Client will receive an OperationOutcom
 * subtype[msg-created-and-sent].system 1..1
 //* subtype[msg-created-and-sent].system = $EdsSubtypes
 //* subtype[msg-created-and-sent].display 1..1
-* subtype[msg-created-and-sent].code from $EdsSubtypesVS
+* subtype[msg-created-and-sent] from $EdsSubtypesVS
 * subtype[msg-created-and-sent].code = #msg-created-and-sent "Message created and sent" (exactly)
 //* subtype[msg-sent]
 * subtype[msg-sent].code 1..1
@@ -107,16 +90,10 @@ not have a successful outcome and the EDS Client will receive an OperationOutcom
     ehmiReceiver 1..1 
 * agent 2..4
 //* ^agent[ehmiSender]
-* agent[ehmiSender].extension ^slicing.discriminator[1].type = #value
-* agent[ehmiSender].extension ^slicing.discriminator[=].path = "value.ofType(Identifier).type"
-* agent[ehmiSender].extension[GLNId] contains 
-	  gln 0..* 
+* agent[ehmiSender].extension contains GLNId named gln 0..* 
 * agent[ehmiSender].name 0..1 MS 
 * agent[ehmiSender].type 1..1 MS 
 * agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type ^short = "$EhmiDeliveryStatusParticipationRoleType#ehmiSender"
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
 * agent[ehmiSender].type.coding.display = "Sender"
 * agent[ehmiSender].who 1..1 MS
 * agent[ehmiSender].who only Reference(Organization)

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_11.1-2_EDS_BDS_EUA_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_11.1-2_EDS_BDS_EUA_created.fsh
@@ -14,34 +14,25 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-BDS-11.1"
 * type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-created-and-sent].code = #msg-created-and-sent 
-* subtype[msg-created-and-sent].display = "Message created and sent"
-//* subtype[msg-created] = $EdsSubtypes#msg-created-and-sent "Message created and sent"
+* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:01.000+02:00" 
-//* outcome = $EhmiDeliveryStatusOutcome#0
 * outcome = http://terminology.hl7.org/CodeSystem/audit-event-outcome#0 "Success"
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-06-EUA-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#EUA
@@ -50,9 +41,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 /* source.observer.identifier.value = "s-06-EUA-Receiver"
 * source.observer.reference = "Device/s-06-EUA-Receiver"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 */
 // Patient
 //* entity[ehmiPatient].what.identifier.value = "PAT1234567890"
@@ -61,22 +50,15 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type.display = "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "Ack1234567890"
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
-// AuditEvent​.entity[1]​.detail[0]​.type (l164​/c39)	error	The property 'value' is invalid
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "Acknowledgement"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
-// AuditEvent​.entity[1]​.detail[1]​.type (l171​/c42)	error	The property 'value' is invalid
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // MessageEnvelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 
 Instance: 011.2-EDS_BDS_Create-EUA-Sender-msg-sent
@@ -94,60 +76,43 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-BDS-11.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-//* subtype[msg-sent] = $EdsSubtypes#msg-sent "Message sent"
-//* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:02.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer.identifier.value = "s-06-EUA-Receiver"
 * source.observer.reference = "Device/s-06-EUA-Receiver"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 // Patient
 //* entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "Ack1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "Acknowledgement"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_11.1-2_EDS_BDS_EUA_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_11.1-2_EDS_BDS_EUA_created.fsh
@@ -14,7 +14,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-BDS-11.1"
 * type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
+* subtype = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:01.000+02:00" 
 * outcome = http://terminology.hl7.org/CodeSystem/audit-event-outcome#0 "Success"
 // ehmiSender
@@ -77,7 +77,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-BDS-11.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:02.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_12.1-2_EDS_BDS_MSH_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_12.1-2_EDS_BDS_MSH_sender.fsh
@@ -17,7 +17,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-12.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:03.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -90,7 +90,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-12.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:04.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_12.1-2_EDS_BDS_MSH_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_12.1-2_EDS_BDS_MSH_sender.fsh
@@ -16,43 +16,35 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-12.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:03.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 
@@ -61,31 +53,22 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message[1]
 * entity[ehmiMessage].what.identifier.value = "Ack1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "Acknowledgement"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope[2]
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope[3]    
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 012.2-EDS_BDS_Create-MSH-Sender-msg-sent
@@ -106,45 +89,34 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-12.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:04.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 //* source.observer.type = $EhmiDeliveryStatusParticipationRoleType#ehmiDevice "Device"
@@ -153,29 +125,20 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "Ack1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "Acknowledgement"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_13.1-2_EDS_BDS_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_13.1-2_EDS_BDS_AP_sender.fsh
@@ -19,7 +19,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * id = "EDS-BDS-13.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:05.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -93,7 +93,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-13.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:06.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_13.1-2_EDS_BDS_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_13.1-2_EDS_BDS_AP_sender.fsh
@@ -17,35 +17,28 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-13.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:05.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -63,31 +56,22 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 013.2-EDS_BDS_Create-AP-Sender-msg-sent
@@ -108,34 +92,27 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-13.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:06.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -153,29 +130,20 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_14.1-2_EDS_BDS_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_14.1-2_EDS_BDS_AP_receiver.fsh
@@ -18,7 +18,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * id = "EDS-BDS-14.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:07.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -83,7 +83,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * id = "EDS-BDS-14.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:08.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_14.1-2_EDS_BDS_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_14.1-2_EDS_BDS_AP_receiver.fsh
@@ -16,35 +16,28 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-14.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:07.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer.identifier.value = "s-04-AP-Receiver"
 * source.observer.reference = "Device/s-04-AP-Receiver"
@@ -57,23 +50,17 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 014.2-EDS_BDS_Create-AP-Receiver-msg-sent
@@ -94,35 +81,28 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-14.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:08.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -140,21 +120,15 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_15.1-2_EDS_BDS_MSH_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_15.1-2_EDS_BDS_MSH_receiver.fsh
@@ -19,7 +19,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * id = "EDS-BDS-15.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:09.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -83,7 +83,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * id = "EDS-BDS-15.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:10.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_15.1-2_EDS_BDS_MSH_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_15.1-2_EDS_BDS_MSH_receiver.fsh
@@ -17,64 +17,50 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-15.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:09.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 // Patient
 //* entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 015.2-EDS_BDS_Create-MSH-Receiver-msg-sent
@@ -95,45 +81,36 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-15.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:10.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Patient
@@ -141,21 +118,15 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_16.1-2_EDS_BDS_EUA_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_16.1-2_EDS_BDS_EUA_finalized.fsh
@@ -15,61 +15,46 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s_01_EUA_Sender
 * id = "EDS-BDS-16.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer.identifier.value = "s_01_EUA_Sender"
 * source.observer.reference = "Device/s-01-EUA-Sender"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 // Patient
 //* entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 */
 
@@ -88,34 +73,27 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 "
 * contained[+] = s-01-EUA-Sender
 * id = "EDS-BDS-16.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received-and-finalized].code = #msg-received-and-finalized
-* subtype[msg-received-and-finalized].system = $EdsSubtypes
-* subtype[msg-received-and-finalized].display = "Message received and finalized"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:12.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-01-EUA-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#EUA
@@ -124,28 +102,20 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 /* source.observer.identifier.value = "s_01_EUA_Sender"
 * source.observer.reference = "Device/s-01-EUA-Sender"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 */
 // Patient
 //* entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_16.1-2_EDS_BDS_EUA_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_16.1-2_EDS_BDS_EUA_finalized.fsh
@@ -16,7 +16,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s_01_EUA_Sender
 * id = "EDS-BDS-16.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -74,7 +74,7 @@ Description: "An instance of an EdsBasicDeliveryStatus.
 * contained[+] = s-01-EUA-Sender
 * id = "EDS-BDS-16.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
+* subtype = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:12.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_17.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_17.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
@@ -23,7 +23,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-17.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
+* subtype = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:09.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -112,7 +112,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-17.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 
 * recorded = "2025-04-01T00:00:10.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_17.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_17.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
@@ -22,25 +22,20 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-17.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-created-and-sent].code = #msg-created-and-sent
-* subtype[msg-created-and-sent].system = $EdsSubtypes
-* subtype[msg-created-and-sent].display = "Message created and sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:09.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -50,59 +45,45 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 /*
@@ -130,26 +111,21 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-17.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 
 * recorded = "2025-04-01T00:00:10.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -159,53 +135,40 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = $EhmiDeliveryStatusEntityMessageType#HomeCareObservation
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 */

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_18.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_18.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
@@ -23,25 +23,20 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-18.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-//* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -51,8 +46,8 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -71,43 +66,31 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 018.2-EDS_BDS_Create-SBDHAck-AP-Sender-msg-sent
@@ -134,25 +117,20 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-18.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:12.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -162,8 +140,8 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -182,41 +160,29 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_18.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_18.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
@@ -24,7 +24,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-18.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -118,7 +118,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-18.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:12.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_19.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_19.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
@@ -24,7 +24,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-19.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:13.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -89,7 +89,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-19.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:14.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_19.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_19.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
@@ -23,25 +23,20 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-19.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:13.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -51,8 +46,8 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer.identifier.value = "s-03-AP-Sender"
 * source.observer.reference = "Device/s-03-AP-Sender"
@@ -61,43 +56,31 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * source.type.display = "AP (Access Point)"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 019.2-EDS_BDS_Create-SBDHAck-AP-Receiver-msg-sent
@@ -105,25 +88,20 @@ InstanceOf: EdsBasicDeliveryStatus
 Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknowledgment for an AP Receiver in a sent status"
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-19.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:14.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -133,8 +111,8 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -148,41 +126,29 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_20.1-2_EDS_BDS_EhmiAck_MSH_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_20.1-2_EDS_BDS_EhmiAck_MSH_finalized.fsh
@@ -22,25 +22,20 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
     - ehmiOrigEnvelopeVersion = 2.0
 "
 * id = "EDS-BDS-20.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:15.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -50,62 +45,46 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 */
 
@@ -133,25 +112,20 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-BDS-20.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received-and-finalized].code = #msg-received-and-finalized
-* subtype[msg-received-and-finalized].system = $EdsSubtypes
-* subtype[msg-received-and-finalized].display = "Message received and finalized"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:16.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -161,65 +135,48 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-02-MSH-Sender)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV2345678901"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH2345678901"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_20.1-2_EDS_BDS_EhmiAck_MSH_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/ehmiMessage_Ack/s_20.1-2_EDS_BDS_EhmiAck_MSH_finalized.fsh
@@ -23,7 +23,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * id = "EDS-BDS-20.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:15.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -113,7 +113,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-BDS-20.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
+* subtype = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:16.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_01.1-2_EDS_PDS_EUA_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_01.1-2_EDS_PDS_EUA_created.fsh
@@ -14,26 +14,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-01-EUA-Sender
 * id = "EDS-PDS-01.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-created-and-sent].code = #msg-created-and-sent 
-* subtype[msg-created-and-sent].display = "Message created and sent"
-//* subtype[msg-created] = $EdsSubtypes#msg-created-and-sent "Message created and sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:01.000+02:00" 
 //* outcome = $EhmiDeliveryStatusOutcome#0
 * outcome = http://terminology.hl7.org/CodeSystem/audit-event-outcome#0 "Success"
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -43,8 +38,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-01-EUA-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#EUA
@@ -52,9 +47,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 /* source.observer.identifier.value = "s-01-EUA-Sender"
 * source.observer.reference = "Device/s-01-EUA-Sender"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 */
 // Patient
 * entity[ehmiPatient].what.identifier.value = "PAT1234567890"
@@ -63,22 +56,17 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type.display = "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
-// AuditEvent​.entity[1]​.detail[0]​.type (l164​/c39)	error	The property 'value' is invalid
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
+
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 // AuditEvent​.entity[1]​.detail[1]​.type (l171​/c42)	error	The property 'value' is invalid
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // MessageEnvelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 
 Instance: 001.2-EDS_PDS_Create-EUA-Sender-msg-sent
@@ -97,26 +85,22 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-01-EUA-Sender
 * id = "EDS-PDS-01.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-//* subtype[msg-sent] = $EdsSubtypes#msg-sent "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+//* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 //* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].display = "Message sent"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:02.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -126,8 +110,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-01-EUA-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#EUA
@@ -135,28 +119,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 /* source.observer.identifier.value = "s-01-EUA-Sender"
 * source.observer.reference = "Device/s-01-EUA-Sender"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 */
 // Patient
 * entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_01.1-2_EDS_PDS_EUA_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_01.1-2_EDS_PDS_EUA_created.fsh
@@ -15,7 +15,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * contained[+] = s-01-EUA-Sender
 * id = "EDS-PDS-01.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
+* subtype = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:01.000+02:00" 
 //* outcome = $EhmiDeliveryStatusOutcome#0
 * outcome = http://terminology.hl7.org/CodeSystem/audit-event-outcome#0 "Success"
@@ -86,9 +86,9 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * contained[+] = s-01-EUA-Sender
 * id = "EDS-PDS-01.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-//* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
-//* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+//* subtype = $EdsSubtypesCS#msg-sent "Message sent"
+//* subtype.system = $EdsSubtypes
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:02.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_02.1-2_EDS_PDS_MSH_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_02.1-2_EDS_PDS_MSH_sender.fsh
@@ -17,24 +17,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-PDS-02.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:03.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -44,18 +40,16 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-02-MSH-Sender)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Patient[0]
@@ -63,31 +57,22 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message[1]
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope[2]
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope[3]    
 /* entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 */
 
@@ -110,26 +95,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-PDS-02.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:04.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -139,17 +119,15 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-02-MSH-Sender)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 /* source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 //* source.observer.type = $EhmiDeliveryStatusParticipationRoleType#ehmiDevice "Device"
@@ -158,29 +136,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_02.1-2_EDS_PDS_MSH_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_02.1-2_EDS_PDS_MSH_sender.fsh
@@ -18,7 +18,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-PDS-02.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:03.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -97,7 +97,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * id = "EDS-PDS-02.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:04.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_03.1-2_EDS_PDS_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_03.1-2_EDS_PDS_AP_sender.fsh
@@ -18,26 +18,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-03-AP-Sender
 * id = "EDS-PDS-03.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:05.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -47,8 +42,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -66,31 +61,22 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 003.2-EDS_PDS_Create-AP-Sender-msg-sent
@@ -112,25 +98,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-03-AP-Sender
 * id = "EDS-PDS-03.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:06.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -140,8 +121,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -159,29 +140,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_03.1-2_EDS_PDS_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_03.1-2_EDS_PDS_AP_sender.fsh
@@ -20,7 +20,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * id = "EDS-PDS-03.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:05.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -99,7 +99,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * contained[+] = s-03-AP-Sender
 * id = "EDS-PDS-03.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:06.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_04.1-2_EDS_PDS_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_04.1-2_EDS_PDS_AP_receiver.fsh
@@ -20,7 +20,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * id = "EDS-PDS-04.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:07.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -100,7 +100,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * id = "EDS-PDS-04.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:08.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_04.1-2_EDS_PDS_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_04.1-2_EDS_PDS_AP_receiver.fsh
@@ -18,26 +18,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-PDS-04.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:07.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -47,8 +42,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -66,31 +61,22 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 004.2-EDS_PDS_Create-AP-Receiver-msg-sent
@@ -112,26 +98,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-PDS-04.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:08.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -141,8 +122,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -160,29 +141,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_05.1-2_EDS_PDS_MSH_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_05.1-2_EDS_PDS_MSH_receiver.fsh
@@ -18,26 +18,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-PDS-05.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:09.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -47,18 +42,16 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Patient
@@ -66,31 +59,22 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 005.2-EDS_PDS_Create-MSH-Receiver-msg-sent
@@ -112,26 +96,21 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-PDS-05.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:10.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -141,18 +120,16 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Patient
@@ -160,29 +137,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_05.1-2_EDS_PDS_MSH_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_05.1-2_EDS_PDS_MSH_receiver.fsh
@@ -20,7 +20,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * id = "EDS-PDS-05.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:09.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -98,7 +98,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * id = "EDS-PDS-05.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
 
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:10.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_06.1-2_EDS_PDS_EUA_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_06.1-2_EDS_PDS_EUA_finalized.fsh
@@ -17,7 +17,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-PDS-06.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -80,7 +80,7 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-PDS-06.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
+* subtype = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:12.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_06.1-2_EDS_PDS_EUA_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_06.1-2_EDS_PDS_EUA_finalized.fsh
@@ -16,25 +16,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-PDS-06.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.000+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -44,35 +39,27 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer.identifier.value = "s-06-EUA-Receiver"
 * source.observer.reference = "Device/s-06-EUA-Receiver"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 // Patient
 * entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 */
 
@@ -92,25 +79,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 "
 * contained[+] = s-06-EUA-Receiver
 * id = "EDS-PDS-06.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received-and-finalized].code = #msg-received-and-finalized
-* subtype[msg-received-and-finalized].system = $EdsSubtypes
-* subtype[msg-received-and-finalized].display = "Message received and finalized"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:12.001+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender"
+
 * agent[ehmiSender].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiSender].who.display = "Aarhus Kommune"
 * agent[ehmiSender].who.identifier.value = "937961000016000"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].requestor = false
@@ -120,8 +102,8 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 * agent[ehmiReceiver].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiReceiver].who.display = "Lægerne Stjernepladsen I/S"
 * agent[ehmiReceiver].who.identifier.value = "698141000016008"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // source
 * source.observer = Reference(Device/s-06-EUA-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#EUA
@@ -130,28 +112,20 @@ Description: "An instance of an EdsPatientDeliveryStatus.
 /* source.observer.identifier.value = "s-06-EUA-Receiver"
 * source.observer.reference = "Device/s-06-EUA-Receiver"
 * source.observer.display = "EUA (End-user Application)"
-* source.type.code = $EhmiDeliveryStatusSourceType#EUA
-* source.type.system = $EhmiDeliveryStatusSourceType
-* source.type.display = "EUA (End-user Application)"
+* source.type = $EhmiDeliveryStatusSourceType#EUA "EUA (End-user Application)"
 */
 // Patient
 * entity[ehmiPatient].what.identifier.value = "PAT1234567890"
 * entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope (Bundle)
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_07.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_07.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
@@ -23,72 +23,54 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-07.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-created-and-sent].code = #msg-created-and-sent
-* subtype[msg-created-and-sent].system = $EdsSubtypes
-* subtype[msg-created-and-sent].display = "Message created and sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:09.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-05-MSH-Receiver)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
@@ -104,13 +86,10 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 */
 // OrigTransportEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 /*
@@ -139,80 +118,60 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-07.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 
 * recorded = "2025-04-01T00:00:10.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer.identifier.value = "s-05-MSH-Receiver"
 * source.observer.reference = "Device/s-05-MSH-Receiver"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = $EhmiDeliveryStatusEntityMessageType#HomeCareObservation
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 */

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_07.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_07.1-2_EDS_BDS_EhmiAck_MSH_created.fsh
@@ -24,7 +24,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-07.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-created-and-sent] = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
+* subtype = $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
 * recorded = "2025-04-01T00:00:09.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -119,7 +119,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-05-MSH-Receiver
 * id = "EDS-BDS-07.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 
 * recorded = "2025-04-01T00:00:10.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_08.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_08.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
@@ -25,7 +25,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-08.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -116,7 +116,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-08.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:12.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_08.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_08.1-2_EDS_BDS_EhmiAck_AP_sender.fsh
@@ -24,34 +24,27 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-08.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-//* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:11.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -70,43 +63,31 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 008.2-EDS_BDS_Create-SBDHAck-AP-Sender-msg-sent
@@ -134,34 +115,27 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-04-AP-Receiver
 * id = "EDS-BDS-08.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:12.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-04-AP-Receiver)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -180,41 +154,29 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 //* entity[ehmiPatient].type = $EhmiDeliveryStatusEntityType#ehmiPatient "Patient"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_09.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_09.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
@@ -24,34 +24,27 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-09.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:13.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -65,43 +58,31 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 
 Instance: 009.2-EDS_BDS_Create-SBDHAck-AP-Receiver-msg-sent
@@ -109,34 +90,27 @@ InstanceOf: EdsBasicDeliveryStatus
 Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknowledgment for an AP Receiver in a sent status"
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-09.2"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-sent].code = #msg-sent
-* subtype[msg-sent].system = $EdsSubtypes
-* subtype[msg-sent].display = "Message sent"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:14.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-03-AP-Sender)
 * source.type.code = $EhmiDeliveryStatusSourceType#AP
@@ -150,41 +124,29 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_09.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_09.1-2_EDS_BDS_EhmiAck_AP_receiver.fsh
@@ -25,7 +25,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-09.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:13.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -91,7 +91,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-03-AP-Sender
 * id = "EDS-BDS-09.2"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-sent] = $EdsSubtypesCS#msg-sent "Message sent"
+* subtype = $EdsSubtypesCS#msg-sent "Message sent"
 * recorded = "2025-04-01T00:00:14.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_10.1-2_EDS_PDS_EhmiAck_MSH_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_10.1-2_EDS_PDS_EhmiAck_MSH_finalized.fsh
@@ -23,88 +23,65 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
     - ehmiOrigEnvelopeVersion = 2.0
 "
 * id = "EDS-BDS-10.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received].code = #msg-received
-* subtype[msg-received].system = $EdsSubtypes
-* subtype[msg-received].display = "Message received"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:15.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 */
 
@@ -133,91 +110,67 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-BDS-10.1"
-* type.code = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* type.system = $EhmiDeliveryStatusTypes
-* type.display = "EHMI messaging event"
-* subtype[msg-received-and-finalized].code = #msg-received-and-finalized
-* subtype[msg-received-and-finalized].system = $EdsSubtypes
-* subtype[msg-received-and-finalized].display = "Message received and finalized"
+* type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
+* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:16.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
 * agent[ehmiSender].name = "Lægerne Stjernepladsen I/S"
 * agent[ehmiSender].requestor = true
-* agent[ehmiSender].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiSender 
-* agent[ehmiSender].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiSender].type.coding.display = "Sender"
+* agent[ehmiSender].type = $EhmiDeliveryStatusParticipationRoleType#ehmiSender "Sender" 
+
 * agent[ehmiSender].who = Reference(Organization/LaegerneStjernepladsen.8200.AarhusN.698141000016008)
 * agent[ehmiSender].who.identifier.value = "698141000016008"
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiSender].extension[GLNId][gln].valueIdentifier.value = "GLN-12345"
+* agent[ehmiSender].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiSender].extension[GLNId].valueIdentifier.value = "GLN-12345"
 // ehmiReceiver
 * agent[ehmiReceiver].name = "Aarhus Kommune - Sundhed og Omsorg"
 * agent[ehmiReceiver].requestor = false
-* agent[ehmiReceiver].type.coding.code = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver
-* agent[ehmiReceiver].type.coding.system = $EhmiDeliveryStatusParticipationRoleType
-* agent[ehmiReceiver].type.coding.display = "Receiver"
+* agent[ehmiReceiver].type = $EhmiDeliveryStatusParticipationRoleType#ehmiReceiver "Receiver"
 * agent[ehmiReceiver].who = Reference(Organization/EER.SOR.HI-AAR-Kommune.937961000016000)
 * agent[ehmiReceiver].who.identifier.value = "937961000016000"
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
-* agent[ehmiReceiver].extension[GLNId][gln].valueIdentifier.value = "GLN-1234"
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.type = $EhmiDeliveryStatusAgentWhoIdentifierTypes#GLN 
+* agent[ehmiReceiver].extension[GLNId].valueIdentifier.value = "GLN-1234"
 // source
 * source.observer = Reference(Device/s-02-MSH-Sender)
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 
 /* source.observer.identifier.value = "s-02-MSH-Sender"
 * source.observer.reference = "Device/s-02-MSH-Sender"
 * source.observer.display = "MSH (Message Service Handler)"
-* source.type.code = $EhmiDeliveryStatusSourceType#MSH
-* source.type.system = $EhmiDeliveryStatusSourceType
+* source.type = $EhmiDeliveryStatusSourceType#MSH
 * source.type.display = "MSH (Application Server)"
 */
 // Message
 * entity[ehmiMessage].what.identifier.value = "MSG3456789012"
-* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiMessage
-* entity[ehmiMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessage].type.display = "Message"
-* entity[ehmiMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
+* entity[ehmiMessage].type = $EhmiDeliveryStatusEntityType#ehmiMessage "Message"
+* entity[ehmiMessage].detail[ehmiMessageType].type = #ehmiMessageType
 * entity[ehmiMessage].detail[ehmiMessageType].valueString = "SBDH_Ack"
-* entity[ehmiMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
+* entity[ehmiMessage].detail[ehmiMessageVersion].type = #ehmiMessageVersion
 * entity[ehmiMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // Message Envelope
 * entity[ehmiMessageEnvelope].what.identifier.value = "ENV1234567890"
-* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope
-* entity[ehmiMessageEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiMessageEnvelope].type.display = "Message Envelope"
-* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageEnvelopeType
+* entity[ehmiMessageEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiMessageEnvelope "Message Envelope"
+* entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].type = #ehmiMessageEnvelopeType
 * entity[ehmiMessageEnvelope].detail[ehmiMessageEnvelopeType].valueString = "FHIR Bundle"
 // Transport Envelope 
 * entity[ehmiTransportEnvelope].what.identifier.value = "ENV3456789012"
-* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope
-* entity[ehmiTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiTransportEnvelope].type.display = "Transport Envelope"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiTransportEnvelope "Transport Envelope"
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"
 // OrigMessage
 * entity[ehmiOrigMessage].what.identifier.value = "MSG1234567890"
-* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigMessage
-* entity[ehmiOrigMessage].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigMessage].type.display = "Original Message"
+* entity[ehmiOrigMessage].type = $EhmiDeliveryStatusEntityType#ehmiOrigMessage "Original Message"
 * entity[ehmiOrigMessage].detail[ehmiMessageType].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageType
 * entity[ehmiOrigMessage].detail[ehmiMessageType].valueString = "HomeCareObservation"
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiMessageVersion
 * entity[ehmiOrigMessage].detail[ehmiMessageVersion].valueString = "1.0"
 // OrigEnvelope
 * entity[ehmiOrigTransportEnvelope].what.identifier.value = "SBDH1234567890"
-* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.code = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope
-* entity[ehmiOrigTransportEnvelope].type.system = $EhmiDeliveryStatusEntityType
-* entity[ehmiOrigTransportEnvelope].type.display = "Original Transport Envelope"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeType
+* entity[ehmiOrigTransportEnvelope].type = $EhmiDeliveryStatusEntityType#ehmiOrigTransportEnvelope "Original Transport Envelope"
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].type = #ehmiTransportEnvelopeType
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeType].valueString = "SBDH"
-* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = $EhmiDeliveryStatusEntityDetailType#ehmiTransportEnvelopeVersion
+* entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].type = #ehmiTransportEnvelopeVersion
 * entity[ehmiOrigTransportEnvelope].detail[ehmiTransportEnvelopeVersion].valueString = "2.0"

--- a/input/fsh/edsBasicDeliveryStatus_samples/s_10.1-2_EDS_PDS_EhmiAck_MSH_finalized.fsh
+++ b/input/fsh/edsBasicDeliveryStatus_samples/s_10.1-2_EDS_PDS_EhmiAck_MSH_finalized.fsh
@@ -24,7 +24,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 "
 * id = "EDS-BDS-10.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received] = $EdsSubtypesCS#msg-received "Message received"
+* subtype = $EdsSubtypesCS#msg-received "Message received"
 * recorded = "2025-04-01T00:00:15.500+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender
@@ -111,7 +111,7 @@ Description: "An instance of an EdsBasicDeliveryStatus containing an SBDH Acknow
 * contained[+] = s-02-MSH-Sender
 * id = "EDS-BDS-10.1"
 * type = $EhmiDeliveryStatusTypes#ehmiMessaging "EHMI messaging event"
-* subtype[msg-received-and-finalized] = $EdsSubtypesCS#msg-received-and-finalized
+* subtype = $EdsSubtypesCS#msg-received-and-finalized
 * recorded = "2025-04-01T00:00:16.501+02:00" 
 * outcome = $EhmiDeliveryStatusOutcome#0
 // ehmiSender

--- a/input/fsh/edsEhmiDeliveryStatusSubTypesValueset.fsh
+++ b/input/fsh/edsEhmiDeliveryStatusSubTypesValueset.fsh
@@ -1,0 +1,13 @@
+// Likely needs to move to the terminology package and get a differnt more specific name as this is a subset of EdsSubtypesValueset
+ValueSet: EhmiDeliveryStatusSubTypesValueset
+Id: ehmi-delivery-status-sub-types-valueset
+Title: "EHMI Delivery Status (EDS) - SubTypes Valueset"
+Description: "ValueSet containing codes for EHMI Delivery Status (EDS) SubTypes"
+* insert Metadata
+//* include codes from valueset $EdsSubtypes
+* include codes from system $EdsSubtypesCS 
+* $EdsSubtypesCS#msg-created-and-sent "Message created and sent"
+* $EdsSubtypesCS#msg-sent "Message sent"
+* $EdsSubtypesCS#msg-received "Message received"
+* $EdsSubtypesCS#msg-received-and-finalized "Message received and finalized"
+

--- a/input/fsh/edsPatientDeliveryStatus.fsh
+++ b/input/fsh/edsPatientDeliveryStatus.fsh
@@ -13,21 +13,7 @@ When the message transaction is not Patient specific then EdsBasicDeliveryStatus
 When successfully submitted from an EDS Client to the EDS Server then the recorded EdsPatientDeliveryStatus has conformed to the profile otherwise it would 
 not have a successful outcome and the EDS Client will receive an OperationOutcome indicating the failure.
 " 
-* ^url = "http://medcomehmi.dk/ig/eds/StructureDefinition/EdsPatientDeliveryStatus"
-* ^text.div = "<div xmlns='http://www.w3.org/1999/xhtml'>StructureDefinition for the EdsPatientDeliveryStatus.</div>"
-* ^text.status = #additional
-* ^contact[0].name = "MedCom"
-* ^contact[=].telecom.value = "https://www.medcom.dk/"
-* ^contact[=].telecom.system = #url
-* ^contact[+].name = "OVI"
-* ^contact[=].telecom.value = "ovi@medcom.dk"
-* ^contact[=].telecom.system = #email
-//* ^jurisdiction = urn:iso:std:iso:3166#CH
-* ^status = #active
-* ^publisher = "MedCom"
-* ^date = "2025-04-01"
-* ^copyright = "CC0-1.0"
-* ^experimental = false
+* insert Metadata
 * entity contains
     ehmiPatient 1..1 
 * entity 3..


### PR DESCRIPTION
PR includes:

- RuleSet for profile metadata.
- Refactored fsh syntax to be more consistent and remove duplicated fsh.
- Fix extension usage of GLNId (`eds-otherId`) on `AuditEvent.agent`
- For `AuditEvent.subtype` 
    - fix: usage of `CodeSystem.url` instead of `ValueSet.url` as `.system` value
    - new proposal for modeling this element. Usage of ValueSet containing subset of codes instead of slices. 